### PR TITLE
add zIndex to 2 for bottom nav

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -21,6 +21,6 @@
 .BelowNavBar-Container {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  background-color: aqua;
+  /* background-color: aqua; */
   overflow: auto;
 }

--- a/src/Components/BottomNavbar.js
+++ b/src/Components/BottomNavbar.js
@@ -11,6 +11,8 @@ export default function BottomNavbar() {
         bottom: 0,
         width: "100%",
         justifyContent: "space-around",
+        zIndex: 2,
+        // backgroundColor: "white",
       }}
       showLabels
       // value={value}


### PR DESCRIPTION
- remove aqua background (to indicate the portion that was taken by BelowNavBar-Container previously)
- add zIndex=2 for BottomNavigation to make it appear on top of the itinerary.name