### PR TITLE
add sort code to ensure the earliest itinerary is always at the top

### DIFF
--- a/src/Components/BelowNavbar.js
+++ b/src/Components/BelowNavbar.js
@@ -79,6 +79,13 @@ export default function BelowNavbar({
     }
   }, [type, userId, dataChanged, value]);
 
+  itineraryActivities.sort((a, b) => {
+    const dateA = new Date(a.prompts.startDate);
+    const dateB = new Date(b.prompts.startDate);
+
+    return dateA - dateB; // For ascending order
+  });
+
   return (
     <div
       style={{


### PR DESCRIPTION
add sort code to ensure the earliest itinerary is always at the top of the page